### PR TITLE
ec2: add dedicated hosts support

### DIFF
--- a/models/apis/ec2/2016-11-15/api-2.json
+++ b/models/apis/ec2/2016-11-15/api-2.json
@@ -5359,6 +5359,10 @@
         "locationName":"item"
       }
     },
+    "AllocationTime":{
+      "type":"timestamp",
+      "timestampFormat":"unixTimestamp"
+    },
     "AllocationState":{
       "type":"string",
       "enum":[
@@ -20897,7 +20901,7 @@
           "locationName":"state"
         },
         "AllocationTime":{
-          "shape":"DateTime",
+          "shape":"AllocationTime",
           "locationName":"allocationTime"
         },
         "ReleaseTime":{

--- a/models/apis/ec2/2016-11-15/api-2.json
+++ b/models/apis/ec2/2016-11-15/api-2.json
@@ -21017,7 +21017,7 @@
           "locationName":"instanceType"
         },
         "InstanceFamily":{
-          "shape":"String",
+          "shape":"InstanceFamily",
           "locationName":"instanceFamily"
         },
         "Sockets":{
@@ -22775,6 +22775,13 @@
           "shape":"ExportEnvironment",
           "locationName":"targetEnvironment"
         }
+      }
+    },
+    "InstanceFamily": {
+      "type":"list",
+      "member": {
+        "shape": "String",
+        "locationName": "item"
       }
     },
     "InstanceFamilyCreditSpecification":{


### PR DESCRIPTION
Service client updates:
- `service/ec2`: Update service API
  - Change the `InstanceFamily` shape to a list of Strings
  - Change the `AllocationTime` shape for the `Host` shape to a UNIX timestamp