### PR TITLE
protocol: add ec2query errors unmarshaling for query protocol

### DIFF
--- a/private/protocol/query/unmarshal_error_test.go
+++ b/private/protocol/query/unmarshal_error_test.go
@@ -37,6 +37,25 @@ func TestUnmarshalError(t *testing.T) {
 			Code: "codeAbc", Msg: "msg123",
 			Status: 400, ReqID: "reqID123",
 		},
+		"Response": {
+			Request: &request.Request{
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header:     http.Header{},
+					Body: ioutil.NopCloser(strings.NewReader(
+						`<Response>
+							<Errors>
+								<Error>
+									<Code>codeAbc</Code><Message>msg123</Message>
+								</Error>
+							</Errors>
+							<RequestID>reqID123</RequestID>
+						</Response>`)),
+				},
+			},
+			Code: "codeAbc", Msg: "msg123",
+			Status: 400, ReqID: "reqID123",
+		},
 		"ServiceUnavailableException": {
 			Request: &request.Request{
 				HTTPResponse: &http.Response{


### PR DESCRIPTION
SDK Enhancements
- `private/protocol/query`: add ec2query errors unmarshaling for query protocol