### PR TITLE
restjson: consider `__type` in UnmarshalTypedError and add CLAIMED status for nodegroup

### DIFF
--- a/models/apis/eks/2017-11-01/api-2.json
+++ b/models/apis/eks/2017-11-01/api-2.json
@@ -1860,6 +1860,7 @@
     "NodegroupStatus":{
       "type":"string",
       "enum":[
+        "CLAIMED",
         "CREATING",
         "PENDING",
         "ACTIVE",

--- a/private/protocol/restjson/unmarshal_error.go
+++ b/private/protocol/restjson/unmarshal_error.go
@@ -56,7 +56,13 @@ func (u *UnmarshalTypedError) UnmarshalError(
 		}
 
 		body = ioutil.NopCloser(&buf)
-		code = jsonErr.Code
+
+		if jsonErr.Type != "" {
+			code = jsonErr.Type
+		} else {
+			code = jsonErr.Code
+		}
+
 		msg = jsonErr.Message
 	}
 

--- a/private/protocol/restjson/unmarshal_error_test.go
+++ b/private/protocol/restjson/unmarshal_error_test.go
@@ -31,6 +31,7 @@ type SimpleError struct {
 }
 
 const otherErrJSON = `{"code":"OtherError", "message":"some message"}`
+const otherWithTypeErrJSON = `{"__type":"OtherError", "message":"some message"}`
 const complexCodeErrJSON = `{"code":"OtherError:foo:bar", "message":"some message"}`
 
 type OtherError struct {
@@ -96,6 +97,15 @@ func TestUnmarshalTypedError(t *testing.T) {
 			Response: &http.Response{
 				Header: http.Header{},
 				Body:   ioutil.NopCloser(strings.NewReader(otherErrJSON)),
+			},
+			Expect: &OtherError{
+				Message2: aws.String("some message"),
+			},
+		},
+		"other error, body __type": {
+			Response: &http.Response{
+				Header: http.Header{},
+				Body:   ioutil.NopCloser(strings.NewReader(otherWithTypeErrJSON)),
 			},
 			Expect: &OtherError{
 				Message2: aws.String("some message"),

--- a/service/eks/api.go
+++ b/service/eks/api.go
@@ -12554,6 +12554,9 @@ func NodegroupIssueCode_Values() []string {
 }
 
 const (
+	// NodegroupStatusClaimed is a NodegroupStatus enum value
+	NodegroupStatusClaimed = "CLAIMED"
+
 	// NodegroupStatusCreating is a NodegroupStatus enum value
 	NodegroupStatusCreating = "CREATING"
 
@@ -12585,6 +12588,7 @@ const (
 // NodegroupStatus_Values returns all elements of the NodegroupStatus enum
 func NodegroupStatus_Values() []string {
 	return []string{
+		NodegroupStatusClaimed,
 		NodegroupStatusCreating,
 		NodegroupStatusPending,
 		NodegroupStatusActive,


### PR DESCRIPTION
SDK Enhancements:
- private/protocol/restjson: consider `__type` in `UnmarshalTypedError`

Service client updates:
- service/eks: Update service API
  - Add `CLAIMED` status for nodegroup